### PR TITLE
docs(readme): adding echarts on installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## Installation
 
 ```sh
-yarn add wrn-echarts
+yarn add wrn-echarts echarts
 ```
 
 Install [react-native-svg](https://github.com/software-mansion/react-native-svg#installation) or [react-native-skia](https://shopify.github.io/react-native-skia/docs/getting-started/installation/) according to your needs.


### PR DESCRIPTION
First of all, the library looks great! I was playing around with the Taro app and the examples look quite interesting. Amazing work

I was also trying to run the example, and noticed that `echarts` are also a requirement but it is not specified in the installation steps. 