### PR TITLE
chore(release): publish 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wrn-echarts",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Echarts for react native.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
1. fix: fixed svg fillOpacity bug in some render processes
2. fix: fixed export default error
3. feat: use expo 48, react native 0.71
4. chore: update readme describe